### PR TITLE
Add bulk methods for all resources and forgeting ids

### DIFF
--- a/src/Tectonic/Localisation/Translator/ResourceCriteria.php
+++ b/src/Tectonic/Localisation/Translator/ResourceCriteria.php
@@ -61,7 +61,7 @@ class ResourceCriteria
     }
 
     /**
-     * Return all resources and their ids.
+     * Return all resource keys.
      */
     public function getResources(): array
     {

--- a/src/Tectonic/Localisation/Translator/ResourceCriteria.php
+++ b/src/Tectonic/Localisation/Translator/ResourceCriteria.php
@@ -85,11 +85,24 @@ class ResourceCriteria
         unset($this->resources[$resource][$key]);
     }
 
+    public function forgetIds(string $resource, int ...$ids): void
+    {
+        $this->resources[$resource] = array_filter(
+            $this->resources[$resource],
+            fn($id) => !in_array($id, $ids)
+        );
+    }
+
     /**
      * Forget a given resource.
      */
     public function forgetResource($resource): void
     {
         unset($this->resources[$resource]);
+    }
+
+    public function all(): array
+    {
+        return $this->resources;
     }
 }

--- a/tests/Translator/ResourceCriteriaTest.php
+++ b/tests/Translator/ResourceCriteriaTest.php
@@ -61,4 +61,31 @@ class ResourceCriteriaTest extends TestCase
         $this->assertCount(1, $resourceCriterion = $this->resourceCriteria->getResources());
         $this->assertEquals(['another'], array_values($resourceCriterion));
     }
+    
+    public function testAll()
+    {
+        $this->resourceCriteria->addResource('resource');
+        $this->resourceCriteria->addResource('another');
+        $this->resourceCriteria->addId('resource', 1);
+        $this->resourceCriteria->addId('resource', 3);
+        $this->resourceCriteria->addId('another', 1);
+        
+        $all = $this->resourceCriteria->all();
+        $this->assertCount(2, $all);
+        $this->assertEquals(['resource', 'another'], array_keys($all));
+        $this->assertEquals([1, 3], $all['resource']);
+        $this->assertEquals([1], $all['another']);
+    }
+    
+    public function testForgetIds()
+    {
+        $this->resourceCriteria->addResource('resource');
+        $this->resourceCriteria->addId('resource', 1);
+        $this->resourceCriteria->addId('resource', 3);
+        $this->resourceCriteria->addId('resource', 5);
+        
+        $this->resourceCriteria->forgetIds('resource', 1, 5);
+        $this->assertCount(1, $ids = $this->resourceCriteria->getIds('resource'));
+        $this->assertEquals([3], array_values($ids));
+    }
 }


### PR DESCRIPTION
Added 2 extra methods for bulk actions on the resources. `all()` and `forgetIds`.