### PR TITLE
Removing &quot; from $translated property via getter

### DIFF
--- a/src/Tectonic/Localisation/Translator/Translations.php
+++ b/src/Tectonic/Localisation/Translator/Translations.php
@@ -8,7 +8,7 @@ trait Translations
      *
      * @var array
      */
-    public $translated = [];
+    protected $translated = [];
 
     /**
      * Returns an array of the field names that can be used for translations.
@@ -69,5 +69,19 @@ trait Translations
         }
 
         return '-new';
+    }
+
+    public function translated()
+    {
+        return $this->replaceStringInArrayValues('&quot;', '&', $this->translated);
+    }
+
+    private function replaceStringInArrayValues(string $search, string $replace, array $keyValuesArray)
+    {
+        return array_map(function ($value) use ($search, $replace) {
+            return is_array($value)
+                ? $this->replaceStringInArrayValues($search, $replace, $value)
+                : str_replace($search, $replace, $value);
+        }, $keyValuesArray);
     }
 }

--- a/tests/Translator/TranslatableTest.php
+++ b/tests/Translator/TranslatableTest.php
@@ -1,6 +1,9 @@
 <?php
+
 namespace Tests\Translator;
 
+use ReflectionClass;
+use ReflectionObject;
 use Tests\Stubs\TranslatableStub;
 use Tests\TestCase;
 
@@ -13,7 +16,7 @@ class TranslatableTest extends TestCase
         $this->translatable = new TranslatableStub;
     }
 
-	public function testTranslatableResource()
+    public function testTranslatableResource()
     {
         $this->assertEquals('TranslatableStub', $this->translatable->getResourceName());
     }
@@ -22,5 +25,40 @@ class TranslatableTest extends TestCase
     {
         $this->assertEquals(['title'], $this->translatable->getTranslatableFields());
     }
+
+    public function testTranslatedIsRemovingQuot()
+    {
+        $this->setPrivateObjectProperty(
+            $this->translatable,
+            'translated',
+            ['en' => ['title' => 'foo &&quot; bar']]
+        );
+
+        $this->assertEquals(
+            'foo &&quot; bar',
+            $this->getPrivateObjectProperty($this->translatable, 'translated') ['en']['title']
+        );
+        $this->assertEquals(
+            'foo && bar',
+            $this->translatable->translated()['en']['title']
+        );
+    }
+
+    private function setPrivateObjectProperty($object, $property, $value)
+    {
+        $reflection = new ReflectionClass($object);
+        $property = $reflection->getProperty($property);
+        /** @noinspection PhpExpressionResultUnusedInspection */
+        $property->setAccessible(true);
+        $property->setValue($object, $value);
+    }
+
+    private function getPrivateObjectProperty($object, $property)
+    {
+        $reflection = new ReflectionObject($object);
+        $property = $reflection->getProperty($property);
+        /** @noinspection PhpExpressionResultUnusedInspection */
+        $property->setAccessible(true);
+        return $property->getValue($object);
+    }
 }
- 


### PR DESCRIPTION
# Problem

For the new editor using Vue, the JS crashes when any translation in translated property contains `&quot;` 
It occurs in the blade template when passing data using `$model->translated`, so the frontend can't handle it.
It wouldn't be a common crash, but once occurring, the entire JS is broken and page can get blank.
____________

# Reason

In the old solution we were injecting the content as html i.e.
`<textarea>Foo &quot; bar</textarea>` (works)
Now it's:
`<vue-component :editor-value="&quot;value&quot;: &quot;Foo >>>> &quot; <<<< bar&quot;" />` (broken)

The highlighted quot is treated the same as the escaped quotes, thus the crash.
____________

# Solution

Replacing `&quot;` with & fixes the issue. As it's happening on PHP level, not in the frontend, the problem are calls like this:
`['translated' => $contentBlock->translated]`
where we rely on an array `$translated` (defined in `Tectonic\Localisation\Translator\Translations`) and we call it in numerous places in the Force. 

Replacing `$contentBlock->translated` with a getter `$contentBlock->translated()` allows to modify the content like this:

```
trait Translations
{
    private $translated = [];   // <---- now private
	
	(..)
	
	public function translated()
    {
        return $this->replaceStringInArrayValues('&quot;', '&', $this->translated);
    }

    private function replaceStringInArrayValues(string $search, string $replace, array $keyValuesArray)
    {
        return array_map(function ($value) use ($search, $replace) {
            return is_array($value)
                ? $this->replaceStringInArrayValues($search, $replace, $value)
                : str_replace($search, $replace, $value);
        }, $keyValuesArray);
    }
```

If this gets approved, then every `->translated` in TF will need to be changed to `->translated()`.